### PR TITLE
Refactor encoder into interface class

### DIFF
--- a/encoder.cpp
+++ b/encoder.cpp
@@ -1,0 +1,96 @@
+// Rotary Encoder
+// Implements interface functions
+
+#include "encoder.h"
+
+Encoder::~Encoder() {
+};
+
+Encoder::Encoder(int clkPin, int dtPin, int swPin) {
+  this->clk_pin = clkPin;
+  this->dt_pin = dtPin;
+  this->sw_pin = swPin;
+};
+
+int Encoder::initRotaryEncoder() {
+  pinMode(this->clk_pin, INPUT);
+  pinMode(this->dt_pin, INPUT);
+  pinMode(this->sw_pin, INPUT);
+
+  encoderPreviousCLK = digitalRead(this->clk_pin); // Initial CLK state
+  encoderPreviousSW = digitalRead(this->sw_pin); // Initial SW state
+
+  return 0;
+}
+
+// Getters & Setters
+
+bool Encoder::toggled() {
+  return currentlyToggled;
+}
+
+bool Encoder::momentaryOn() {
+  return currentlyMomentaryOn;
+}
+
+// Public Methods
+
+void Encoder::readEncoderSwitch(void (*encoderSwitchMomentaryHandler)()) {
+  encoderCurrentSW = digitalRead(this->sw_pin);
+
+  // If the SW didn't change, then the encoder wasn't pressed or released. Do nothing.
+  if (encoderCurrentSW == encoderPreviousSW) {
+    return;
+  }
+
+  if (encoderCurrentSW == LOW) {
+    Serial.println("Encoder Pressed");
+    currentlyToggled = !currentlyToggled;
+    // Trigger a momentary handler if one is supplied
+    encoderSwitchMomentaryHandler();
+  }
+
+  if (encoderCurrentSW == HIGH) {
+    Serial.println("Encoder Released");
+  }
+
+  encoderPreviousSW = encoderCurrentSW;
+}
+
+// TODO: Make function argument optional
+void Encoder::readEncoderSwitchMomentary(void (*encoderSwitchMomentaryHandler)()) {
+  // If the SW didn't change, then the encoder wasn't pressed or released. Do nothing.
+  if (encoderCurrentSW == encoderPreviousSW) {
+    return;
+  }
+
+  if (encoderCurrentSW == LOW) {
+    Serial.println("Encoder Pressed");
+    encoderSwitchMomentaryHandler();
+  }
+}
+
+void Encoder::readEncoderRotation(void (*clockwiseHandler)(), void (*counterclockwiseHandler)()) {
+  encoderCurrentCLK = digitalRead(this->clk_pin);
+
+  // If the CLK didn't change, then the encoder didn't move. Do nothing.
+  if (encoderCurrentCLK == encoderPreviousCLK) {
+    return;
+  }
+
+  encoderPreviousCLK = encoderCurrentCLK;
+
+  // Extremely basic debounce.
+  // Current encoder only latches on 1 and reads 0 when not latched.
+  // Only compute rotation when the encoder latches.
+  if (encoderCurrentCLK == 0) {
+    return;
+  }
+
+  // Both CLK and DT are HIGH when rotating counterclockwise
+  if (encoderCurrentCLK == digitalRead(this->dt_pin)) { // Counterclockwise
+    counterclockwiseHandler();
+  } else { // Clockwise
+    clockwiseHandler();
+  }
+}

--- a/menu.h
+++ b/menu.h
@@ -56,7 +56,7 @@ void initMenu() {
 
 void highlightSelectedMenuItemLabel(uint8_t renderingMenuItemIndex) {
   // If we've stepped into the values of an item, skip
-  if (encoderToggled) {
+  if (encoder.toggled()) {
     return;
   }
 
@@ -70,7 +70,7 @@ void highlightSelectedMenuItemLabel(uint8_t renderingMenuItemIndex) {
 
 void highlightSelectedMenuItemValue(uint8_t renderingMenuItemIndex) {
   // If we have not stepped into the values of an item, skip
-  if (!encoderToggled) {
+  if (!encoder.toggled()) {
     return;
   }
 
@@ -82,9 +82,8 @@ void highlightSelectedMenuItemValue(uint8_t renderingMenuItemIndex) {
   }
 }
 
-void renderMenu(uint8_t nextMenuItemIndex) {
-  activeMenuItemIndex = nextMenuItemIndex;
-  
+void renderMenu() {
+  display.clearDisplay();
   display.setCursor(0, 0);
   display.setTextSize(1);
 
@@ -100,4 +99,6 @@ void renderMenu(uint8_t nextMenuItemIndex) {
     highlightSelectedMenuItemValue(i);
     display.println(menuItems[i].value);
   }
+
+  display.display();
 }


### PR DESCRIPTION
The encoder used to be simply crammed into the header file as a basic means to initially separate the code.
This cleans things up and lets us use the instance of the Encoder class as an interface, to also provide some encapsulation.

**Misc Changes**:
1. After the sequencer merge I also went back to do some minor cleanup on the menu functionality and make sure everything is working alongside the newer changes
2. While I was at it I decoupled the encoder from the menu, so that it's only providing the abstract handlers and doesn't partake in keeping the menu state or bounds
