### PR TITLE
Pause on all notes off message

### DIFF
--- a/PewBox.ino
+++ b/PewBox.ino
@@ -88,6 +88,11 @@ void loop() {
         Serial.println("Stop");
         sequencerPause();
         break;
+      case midi::ControlChange:
+        if (MIDI.getData1() == 123) {
+          Serial.println("[Channel Mode Message] All Notes Off");
+          sequencerPause();
+        }
       case midi::NoteOn:
         Serial.println("Note On");
         break;


### PR DESCRIPTION
When pushing stop, some devices have a small delay before sending the stop message, but send a channel mode notes off message immediately. React to both to pause the sequencer.